### PR TITLE
fix: check for windows rstudio in RStudio/ not RStudio/bin/ fixes #32

### DIFF
--- a/src/check_setup.sh
+++ b/src/check_setup.sh
@@ -82,10 +82,10 @@ if [[ "$(uname)" == 'Darwin' ]]; then
 elif [[ "$OSTYPE" == 'msys' ]]; then
     # Rstudio on windows does not accept the --version flag when run interactively
     # so this section can only be troubleshot from the script
-    if ! $(grep -iq "202*" <<< "$('/c//Program Files/RStudio/bin/rstudio' --version)"); then
+    if ! $(grep -iq "202*" <<< "$('/c/Program Files/RStudio/rstudio' --version)"); then
         echo "MISSING   rstudio 2021  or higher" >> check_setup.log
     else
-        echo "OK        rstudio "$('/c//Program Files/RStudio/bin/rstudio' --version) >> check_setup.log
+        echo "OK        rstudio "$('/c/Program Files/RStudio/rstudio' --version) >> check_setup.log
     fi
     # tlmgr needs .bat appended on windows and it cannot be tested as an exectuable with `-x`
     if ! [ "$(command -v tlmgr.bat)" ]; then


### PR DESCRIPTION
See #32 for background.

- Checkts for rstudio in `RStudio/` instead of `RStudio/bin/`